### PR TITLE
feat: add error messages aggregator

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Antd Zod validation
+# Antd Zod Validation
 
 The aim of this library is to enable seamless integration of Zod validation with Antd form fields.
 
@@ -11,7 +11,6 @@ Link to npm package [antd-zod](https://npmjs.com/package/antd-zod).
 
 ### Older version
 - For Antd@^4.0.0 use antd-zod@^4.0.0
-
 
 ## Usage
 
@@ -45,16 +44,36 @@ const SimpleForm = () => {
 };
 ```
 
+## Customizing Error Messages
+
+You can customize how multiple error messages are handled using the `aggregateErrorMessages` option.
+
+### Example: Show Only the First Error
+```jsx
+const rule = createSchemaFieldRule(CustomFormValidationSchema, {
+  aggregateErrorMessages: (prev, next) => prev,
+});
+```
+
+### Example: Concatenate Errors with a Comma
+```jsx
+const rule = createSchemaFieldRule(CustomFormValidationSchema, {
+  aggregateErrorMessages: (prev, next) => `${prev}, ${next}`,
+});
+```
+
+This allows greater flexibility in how error messages are displayed within your forms.
+
 ## Examples
 All examples are in Storybook stories
 
 - Basic examples - https://github.com/MrBr/antd-zod/blob/main/stories/basic.stories.tsx
 - Refined examples - https://github.com/MrBr/antd-zod/blob/main/stories/refined.stories.tsx
 
-To start storybook locally, install depenedencies and run `npm run storybook`.
+To start Storybook locally, install dependencies and run `npm run storybook`.
 
 ## Specifications
-Antd Form.Item (rc-field-form) has a certain validation lifecycle which works the best with Form.Item rules. In order to respect that behaviour, `antd-zod` provides a way to create a generic rule that will validate all schema properties and refinements on a field level.
+Antd Form.Item (rc-field-form) has a certain validation lifecycle which works the best with Form.Item rules. In order to respect that behavior, `antd-zod` provides a way to create a generic rule that will validate all schema properties and refinements on a field level.
 
 - Base schema for Form data must be an object
 - Object may have refinements on a root level

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,3 +5,8 @@ export type AntdFormZodSchema<T extends ZodRawShape> =
   | z.ZodEffects<z.ZodObject<T>>
   | z.ZodEffects<z.ZodEffects<z.ZodObject<T>>>
   | z.ZodEffects<z.ZodEffects<z.ZodEffects<z.ZodObject<T>>>>;
+
+export type CreateSchemaFieldRuleOptions = {aggregateErrorMessages: (prev: string, next: string) => string};
+export type FormatErrorsOptions = {aggregateErrorMessages: (prev: string, next: string) => string};
+export type ValidateFieldsOptions = {aggregateErrorMessages: (prev: string, next: string) => string};
+

--- a/src/utils/createSchemaFieldRule.spec.ts
+++ b/src/utils/createSchemaFieldRule.spec.ts
@@ -11,9 +11,13 @@ const mockFormInstance = (values: {}) =>
 
 const mockFormFieldRule = (field: string) => ({ field }) as RuleObject;
 
+const defaultOptions = {
+  aggregateErrorMessages: (prev: string, next: string) => `${prev}, ${next}`,
+};
+
 describe("createSchemaFieldValidator", () => {
   it("should validate successfully NameSchema values", async () => {
-    const rule = createSchemaFieldRule(NameSchema);
+    const rule = createSchemaFieldRule(NameSchema, defaultOptions);
     const formInstance = mockFormInstance({ name: "Test" });
     const fieldRule = mockFormFieldRule("name");
 
@@ -22,7 +26,7 @@ describe("createSchemaFieldValidator", () => {
     ).resolves.toEqual(undefined);
   });
   it("should reject invalid NameSchema values", async () => {
-    const rule = createSchemaFieldRule(NameSchema);
+    const rule = createSchemaFieldRule(NameSchema, defaultOptions);
     const formInstance = mockFormInstance({});
     const fieldRule = mockFormFieldRule("name");
 
@@ -31,7 +35,7 @@ describe("createSchemaFieldValidator", () => {
     ).rejects.toEqual("Required");
   });
   it("should validate successfully NestedRefinedSchema values", async () => {
-    const rule = createSchemaFieldRule(NestedRefinedSchema);
+    const rule = createSchemaFieldRule(NestedRefinedSchema, defaultOptions);
     const formInstance = mockFormInstance({ user: { name: "Luka" } });
     const fieldRule = mockFormFieldRule("name");
 
@@ -40,7 +44,7 @@ describe("createSchemaFieldValidator", () => {
     ).resolves.toEqual(undefined);
   });
   it("should reject undefined NestedRefinedSchema values", async () => {
-    const rule = createSchemaFieldRule(NestedRefinedSchema);
+    const rule = createSchemaFieldRule(NestedRefinedSchema, defaultOptions);
     const formInstance = mockFormInstance({});
     const fieldRule = mockFormFieldRule("user.name");
 
@@ -49,7 +53,7 @@ describe("createSchemaFieldValidator", () => {
     ).rejects.toEqual("Required");
   });
   it("should reject invalid NestedRefinedSchema values", async () => {
-    const rule = createSchemaFieldRule(NestedRefinedSchema);
+    const rule = createSchemaFieldRule(NestedRefinedSchema, defaultOptions);
     const formInstance = mockFormInstance({ user: { name: "test" } });
     const fieldRule = mockFormFieldRule("user.name");
 

--- a/src/utils/createSchemaFieldRule.ts
+++ b/src/utils/createSchemaFieldRule.ts
@@ -7,7 +7,7 @@ import prepareValues from "./prepareValues";
 const createSchemaFieldRule =
   <T extends ZodRawShape>(
     schema: AntdFormZodSchema<T>,
-    options: CreateSchemaFieldRuleOptions,
+    options?: CreateSchemaFieldRuleOptions,
   ): RuleRender =>
   ({ getFieldsValue }) => ({
     validator: (rule) =>

--- a/src/utils/createSchemaFieldRule.ts
+++ b/src/utils/createSchemaFieldRule.ts
@@ -1,11 +1,14 @@
 import { ZodRawShape } from "zod";
 import { RuleRender } from "rc-field-form/lib/interface";
-import { AntdFormZodSchema } from "../types";
+import { AntdFormZodSchema, CreateSchemaFieldRuleOptions } from "../types";
 import validateFields from "./validateFields";
 import prepareValues from "./prepareValues";
 
 const createSchemaFieldRule =
-  <T extends ZodRawShape>(schema: AntdFormZodSchema<T>): RuleRender =>
+  <T extends ZodRawShape>(
+    schema: AntdFormZodSchema<T>,
+    options: CreateSchemaFieldRuleOptions,
+  ): RuleRender =>
   ({ getFieldsValue }) => ({
     validator: (rule) =>
       new Promise(async (resolve, reject) => {
@@ -16,6 +19,7 @@ const createSchemaFieldRule =
         const errors = await validateFields<T>(
           schema,
           prepareValues(schema, values),
+          options,
         );
 
         if (!!errors && errors[field]) {

--- a/src/utils/formatErrors.spec.ts
+++ b/src/utils/formatErrors.spec.ts
@@ -1,6 +1,19 @@
-import z from "zod";
+import z, { ZodError, ZodIssue } from "zod";
 import formatErrors from "./formatErrors";
 import prepareValues from "./prepareValues";
+
+const defaultOptions = {
+  aggregateErrorMessages: (prev: string, next: string) => `${prev}, ${next}`,
+};
+
+const fakeIssues: ZodIssue[] = [
+  { code: "custom", message: "Error one", path: ["field"] },
+  { code: "custom", message: "Error two", path: ["field"] },
+];
+
+const fakeZodError = new ZodError(fakeIssues);
+
+const schema = z.object({ field: z.string() });
 
 describe("formatErrors", () => {
   it("should return empty errors", async () => {
@@ -12,7 +25,7 @@ describe("formatErrors", () => {
     if (res.success) {
       return;
     }
-    const formattedErrors = formatErrors<{}>(schema, res.error);
+    const formattedErrors = formatErrors<{}>(schema, res.error, defaultOptions);
 
     expect(formattedErrors).toEqual({});
   });
@@ -25,7 +38,7 @@ describe("formatErrors", () => {
     if (res.success) {
       return;
     }
-    const formattedErrors = formatErrors<{}>(schema, res.error);
+    const formattedErrors = formatErrors<{}>(schema, res.error, defaultOptions);
 
     expect(formattedErrors).toEqual({ prop: "Required" });
   });
@@ -40,8 +53,23 @@ describe("formatErrors", () => {
     if (res.success) {
       return;
     }
-    const formattedErrors = formatErrors<{}>(schema, res.error);
+    const formattedErrors = formatErrors<{}>(schema, res.error, defaultOptions);
 
     expect(formattedErrors).toEqual({ "prop.child": "Required" });
+  });
+  it("should return only the first error when aggregator returns previous error", () => {
+    const options = {
+      aggregateErrorMessages: (prev: string, next: string) => prev, // return only the first error
+    };
+    const formattedErrors = formatErrors(schema, fakeZodError, options);
+    expect(formattedErrors).toEqual({ field: "Error one" });
+  });
+
+  it("should join multiple errors with a comma when aggregator is used", () => {
+    const options = {
+      aggregateErrorMessages: (prev: string, next: string) => `${prev}, ${next}`, // join errors with a comma
+    };
+    const formattedErrors = formatErrors(schema, fakeZodError, options);
+    expect(formattedErrors).toEqual({ field: "Error one, Error two" });
   });
 });

--- a/src/utils/validateFields.spec.ts
+++ b/src/utils/validateFields.spec.ts
@@ -6,40 +6,44 @@ import {
 } from "../fixtures";
 import validateFields from "./validateFields";
 
+const defaultOptions = {
+  aggregateErrorMessages: (prev: string, next: string) => `${prev}, ${next}`,
+};
+
 describe("validateFields", () => {
-  it("should returns without errors", async () => {
-    expect(await validateFields(NameSchema, { name: "Test" })).toEqual({});
+  it("should return without errors", async () => {
+    expect(await validateFields(NameSchema, { name: "Test" }, defaultOptions)).toEqual({});
   });
   it("should return errors", async () => {
-    expect(await validateFields(NameSchema, {})).toEqual({
+    expect(await validateFields(NameSchema, {}, defaultOptions)).toEqual({
       name: "Required",
     });
   });
   it("should return errors for nested schemas", async () => {
-    expect(await validateFields(NestedRefinedSchema, {})).toEqual({
+    expect(await validateFields(NestedRefinedSchema, {}, defaultOptions)).toEqual({
       "user.name": "Required",
     });
   });
   it("should return errors for primitive array field", async () => {
-    expect(await validateFields(ArrayNumberFieldSchema, {})).toEqual({
+    expect(await validateFields(ArrayNumberFieldSchema, {}, defaultOptions)).toEqual({
       numbers: "Required",
     });
   });
   it("should return errors for object array field", async () => {
     expect(
-      await validateFields(ArrayUserFieldSchema, { users: "invalid value" }),
+      await validateFields(ArrayUserFieldSchema, { users: "invalid value" }, defaultOptions),
     ).toEqual({
       users: "Expected array, received string",
     });
   });
 
   it("should return errors for object array field items", async () => {
-    expect(await validateFields(ArrayUserFieldSchema, { users: [1] })).toEqual({
+    expect(await validateFields(ArrayUserFieldSchema, { users: [1] }, defaultOptions)).toEqual({
       "users.0": "Expected object, received number",
     });
 
     expect(
-      await validateFields(ArrayUserFieldSchema, { users: [{ name: 10 }] }),
+      await validateFields(ArrayUserFieldSchema, { users: [{ name: 10 }] }, defaultOptions),
     ).toEqual({
       "users.0.name": "Expected string, received number",
     });

--- a/src/utils/validateFields.ts
+++ b/src/utils/validateFields.ts
@@ -1,4 +1,4 @@
-import { AntdFormZodSchema } from "../types";
+import { AntdFormZodSchema, ValidateFieldsOptions } from "../types";
 import { ZodRawShape } from "zod";
 import prepareValues from "./prepareValues";
 import formatErrors from "./formatErrors";
@@ -6,6 +6,7 @@ import formatErrors from "./formatErrors";
 const validateFields = async <T extends ZodRawShape>(
   schema: AntdFormZodSchema<T>,
   values: {},
+  options: ValidateFieldsOptions,
 ): Promise<{ [key: string]: string }> => {
   const valuesWithPlaceholders = prepareValues(schema, values);
 
@@ -15,7 +16,7 @@ const validateFields = async <T extends ZodRawShape>(
     return {} as Record<keyof T, string>;
   }
 
-  return formatErrors(schema, res.error);
+  return formatErrors(schema, res.error, options);
 };
 
 export default validateFields;

--- a/src/utils/validateFields.ts
+++ b/src/utils/validateFields.ts
@@ -6,7 +6,7 @@ import formatErrors from "./formatErrors";
 const validateFields = async <T extends ZodRawShape>(
   schema: AntdFormZodSchema<T>,
   values: {},
-  options: ValidateFieldsOptions,
+  options?: ValidateFieldsOptions,
 ): Promise<{ [key: string]: string }> => {
   const valuesWithPlaceholders = prepareValues(schema, values);
 


### PR DESCRIPTION
This PR enhances antd-zod by introducing a customizable error aggregation mechanism. Instead of only returning a single error per field, developers now have control over how multiple error messages are combined using a new option: **`aggregateErrorMessages`**.

## Changes
- **New Option: `aggregateErrorMessages`**
  - Accepts a function with the signature `(prev: string, next: string) => string` that defines how to combine error messages for the same field.
  - This allows users to join multiple errors (e.g., with a comma) or simply return the first error.

- **Refactored Modules**
  - **`createSchemaFieldRule.ts`**
    - Updated to accept the `aggregateErrorMessages` option.
    - Passes the option to `validateFields` during rule creation.
  - **`validateFields.ts`**
    - Updated to forward the `aggregateErrorMessages` option to `formatErrors`.
  - **`formatErrors.ts`**
    - Refactored the error formatting logic to aggregate multiple errors using the provided `aggregateErrorMessages` function.
    - Ensures that when multiple errors exist for the same field, they are combined according to the user’s strategy.

- **Test Updates**
  - Modified existing tests for `createSchemaFieldRule`, `validateFields`, and `formatErrors` to supply the new option.
  - Added new tests in `formatErrors.test.ts` to verify that different aggregation strategies work as expected:
    - One test returns only the first error.
    - Another joins errors with a comma.

## Motivation
This change addresses a common need where developers want more control over error message presentation in forms. Previously, antd-zod only returned one error per field, which limited flexibility. With the new aggregation option, developers can tailor the error display—whether that means showing all errors concatenated or just the primary error—thereby improving the user experience in form validations.

## Impact
- **Backward Compatible:** Developers can maintain existing behavior by passing an aggregation function that returns the first error (e.g., `(prev, next) => prev`).
- **Enhanced Flexibility:** Users now have full control over error message aggregation without altering core validation functionality.

Looking forward to your feedback!