### PR TITLE
feat: add multiple errors

### DIFF
--- a/src/utils/createSchemaFieldRule.spec.ts
+++ b/src/utils/createSchemaFieldRule.spec.ts
@@ -28,7 +28,7 @@ describe("createSchemaFieldValidator", () => {
 
     await expect(
       rule(formInstance).validator?.(fieldRule, {}, () => {}),
-    ).rejects.toEqual("Required");
+    ).rejects.toEqual(["Required"]);
   });
   it("should validate successfully NestedRefinedSchema values", async () => {
     const rule = createSchemaFieldRule(NestedRefinedSchema);
@@ -46,7 +46,7 @@ describe("createSchemaFieldValidator", () => {
 
     await expect(
       rule(formInstance).validator?.(fieldRule, {}, () => {}),
-    ).rejects.toEqual("Required");
+    ).rejects.toEqual(["Required"]);
   });
   it("should reject invalid NestedRefinedSchema values", async () => {
     const rule = createSchemaFieldRule(NestedRefinedSchema);
@@ -55,6 +55,6 @@ describe("createSchemaFieldValidator", () => {
 
     await expect(
       rule(formInstance).validator?.(fieldRule, {}, () => {}),
-    ).rejects.toEqual("Must be Luka");
+    ).rejects.toEqual(["Must be Luka"]);
   });
 });

--- a/src/utils/formatErrors.spec.ts
+++ b/src/utils/formatErrors.spec.ts
@@ -1,6 +1,15 @@
-import z from "zod";
+import z, { ZodError, ZodIssue } from "zod";
 import formatErrors from "./formatErrors";
 import prepareValues from "./prepareValues";
+
+const fakeIssues: ZodIssue[] = [
+  { code: "custom", message: "Error one", path: ["field"] },
+  { code: "custom", message: "Error two", path: ["field"] },
+];
+
+const fakeZodError = new ZodError(fakeIssues);
+
+const schema = z.object({ field: z.string() });
 
 describe("formatErrors", () => {
   it("should return empty errors", async () => {
@@ -27,7 +36,7 @@ describe("formatErrors", () => {
     }
     const formattedErrors = formatErrors<{}>(schema, res.error);
 
-    expect(formattedErrors).toEqual({ prop: "Required" });
+    expect(formattedErrors).toEqual({ prop: ["Required"] });
   });
   it("should format nested prop.child error", async () => {
     const schema = z.object({
@@ -42,6 +51,11 @@ describe("formatErrors", () => {
     }
     const formattedErrors = formatErrors<{}>(schema, res.error);
 
-    expect(formattedErrors).toEqual({ "prop.child": "Required" });
+    expect(formattedErrors).toEqual({ "prop.child": ["Required"] });
+  });
+  it("should return multiple errors", () => {
+    const formattedErrors = formatErrors(schema, fakeZodError);
+    console.log(formattedErrors)
+    expect(formattedErrors).toEqual({ field: ["Error one", "Error two"] });
   });
 });

--- a/src/utils/formatErrors.ts
+++ b/src/utils/formatErrors.ts
@@ -7,7 +7,7 @@ import getIssueAntdPath from "./getIssueAntdPath";
 const formatErrors = <T extends ZodRawShape>(
   schema: ZodTypeAny,
   errors: ZodError<T>,
-): { [key: string]: string } => {
+): { [key: string]: string[] } => {
   if (errors.issues.length === 0) {
     return {};
   }
@@ -22,14 +22,18 @@ const formatErrors = <T extends ZodRawShape>(
     (formattedErrors, issue) => {
       try {
         const path = getIssueAntdPath(schema, issue);
-        formattedErrors[path] = issue.message;
+        if (formattedErrors[path]) {
+          formattedErrors[path].push(issue.message);
+        } else {
+          formattedErrors[path] = [issue.message];
+        }
       } catch (e) {
         console.warn(e);
       }
 
       return formattedErrors;
     },
-    {} as { [key: string]: string },
+    {} as { [key: string]: string[] },
   );
 };
 

--- a/src/utils/validateFields.spec.ts
+++ b/src/utils/validateFields.spec.ts
@@ -12,36 +12,36 @@ describe("validateFields", () => {
   });
   it("should return errors", async () => {
     expect(await validateFields(NameSchema, {})).toEqual({
-      name: "Required",
+      name: ["Required"],
     });
   });
   it("should return errors for nested schemas", async () => {
     expect(await validateFields(NestedRefinedSchema, {})).toEqual({
-      "user.name": "Required",
+      "user.name": ["Required"],
     });
   });
   it("should return errors for primitive array field", async () => {
     expect(await validateFields(ArrayNumberFieldSchema, {})).toEqual({
-      numbers: "Required",
+      numbers: ["Required"],
     });
   });
   it("should return errors for object array field", async () => {
     expect(
       await validateFields(ArrayUserFieldSchema, { users: "invalid value" }),
     ).toEqual({
-      users: "Expected array, received string",
+      users: ["Expected array, received string"],
     });
   });
 
   it("should return errors for object array field items", async () => {
     expect(await validateFields(ArrayUserFieldSchema, { users: [1] })).toEqual({
-      "users.0": "Expected object, received number",
+      "users.0": ["Expected object, received number"],
     });
 
     expect(
       await validateFields(ArrayUserFieldSchema, { users: [{ name: 10 }] }),
     ).toEqual({
-      "users.0.name": "Expected string, received number",
+      "users.0.name": ["Expected string, received number"],
     });
   });
 });

--- a/src/utils/validateFields.ts
+++ b/src/utils/validateFields.ts
@@ -6,13 +6,13 @@ import formatErrors from "./formatErrors";
 const validateFields = async <T extends ZodRawShape>(
   schema: AntdFormZodSchema<T>,
   values: {},
-): Promise<{ [key: string]: string }> => {
+): Promise<{ [key: string]: string[] }> => {
   const valuesWithPlaceholders = prepareValues(schema, values);
 
   const res = await schema.safeParseAsync(valuesWithPlaceholders);
 
   if (res.success) {
-    return {} as Record<keyof T, string>;
+    return {} as Record<keyof T, string[]>;
   }
 
   return formatErrors(schema, res.error);

--- a/stories/basic.stories.tsx
+++ b/stories/basic.stories.tsx
@@ -30,6 +30,7 @@ const Child = z.object({
 });
 
 const BasicSchema = z.object({
+  email: z.string().email().min(5).max(15).includes('.com'),
   name: z.string().refine((value) => value.length > 2, {
     message: "Must have more than 2 chars",
   }),
@@ -46,6 +47,9 @@ const rule = createSchemaFieldRule(BasicSchema);
 const BasicForm = () => {
   return (
     <Form>
+      <Form.Item label="Enter email" name="email" rules={[rule]}>
+        <Input />
+      </Form.Item>
       <Form.Item label="Enter name" name="name" rules={[rule]}>
         <Input />
       </Form.Item>


### PR DESCRIPTION
This PR refactors the error formatting in antd-zod so that multiple validation errors for a given field are returned as **arrays of strings** rather than a single concatenated error message. This change improves flexibility and allows consumers to display all errors separately.

## Changes

### 1. **`formatErrors.ts`**
- **Refactor Error Formatter:**  
  Instead of accumulating a single string per field, error messages are now collected into an array.
  - If multiple issues occur on the same field, each error message is pushed into an array.
- **Example Change:**
  ```ts
  return errors.issues.reduce((formattedErrors, issue) => {
    try {
      const path = getIssueAntdPath(schema, issue);
      if (formattedErrors[path]) {
        formattedErrors[path].push(issue.message);
      } else {
        formattedErrors[path] = [issue.message];
      }
    } catch (e) {
      console.warn(e);
    }
    return formattedErrors;
  }, {} as { [key: string]: string[] });
  ```

### 2. **`validateFields.ts`**
- **Return Type Updated:**  
  The function now returns a promise resolving to an object with error messages as string arrays (`{ [key: string]: string[] }`).
- **Example Change:**
  ```ts
  const validateFields = async <T extends ZodRawShape>(
    schema: AntdFormZodSchema<T>,
    values: {},
  ): Promise<{ [key: string]: string[] }> => {
    const valuesWithPlaceholders = prepareValues(schema, values);
    const res = await schema.safeParseAsync(valuesWithPlaceholders);
    if (res.success) {
      return {} as Record<keyof T, string[]>;
    }
    return formatErrors(schema, res.error);
  };
  ```

### 3. **`createSchemaFieldRule.ts`**
- **Updated Validator Behavior:**  
  Tests have been updated to expect rejection with an array of errors (e.g., `["Required"]`).

### 4. **Tests**
- **Updated and New Tests:**  
  - Tests for `formatErrors`, `validateFields`, and `createSchemaFieldRule` have been updated to account for the new error array format.
  - New tests ensure that multiple errors are properly returned.
  - For example, validating an empty string on a required field now returns `{ field: ["Required"] }` instead of a single string.

## Motivation

- **Enhanced Error Handling:**  
  Returning errors as arrays provides better control and allows for more flexible UI designs.
- **Better Testing & Documentation:**  
  Updated tests and a Storybook example ensure clarity and proper usage of the new error format.

## Impact

- **Improved User Experience:**  
  Consumers of antd-zod can now choose to display multiple errors separately in any format they prefer.

---

Thank you for reviewing this PR. I look forward to your feedback and suggestions!