### PR TITLE
feat: zod-4 support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "@types/lodash.merge": "^4.6.8",
         "@typescript-eslint/eslint-plugin": "^6.7.5",
         "@typescript-eslint/parser": "^6.7.5",
+        "@zod/mini": "^4.0.0-beta.20250420T053007",
         "antd": "^5.20.5",
         "jest": "^29.7.0",
         "jest-environment-jsdom": "^29.7.0",
@@ -35,12 +36,11 @@
         "storybook": "^7.4.6",
         "ts-jest": "^29.1.1",
         "tsup": "^8.0.2",
-        "typescript": "^5.2.2",
-        "zod": "^3.23.8"
+        "typescript": "^5.2.2"
       },
       "peerDependencies": {
-        "antd": "^5.20.5",
-        "zod": ">=3.0.0"
+        "@zod/core": ">=0.8.1",
+        "antd": "^5.20.5"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -6961,6 +6961,28 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
       "dev": true
+    },
+    "node_modules/@zod/core": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@zod/core/-/core-0.8.1.tgz",
+      "integrity": "sha512-djj8hPhxIHcG8ptxITaw/Bout5HJZ9NyRbKr95Eilqwt9R0kvITwUQGDU+n+MVdsBIka5KwztmZSLti22F+P0A==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/@zod/mini": {
+      "version": "4.0.0-beta.20250420T053007",
+      "resolved": "https://registry.npmjs.org/@zod/mini/-/mini-4.0.0-beta.20250420T053007.tgz",
+      "integrity": "sha512-PnQwkzlUbUj6A2GKbqhskH/v58m2WfmP+dbXevzzMdvVA7H/KNao37YWhHOTjBzf+xykCXNoLwfwnPMIsU0hOA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@zod/core": "0.8.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
     },
     "node_modules/abab": {
       "version": "2.0.6",
@@ -18327,15 +18349,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/zod": {
-      "version": "3.23.8",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.23.8.tgz",
-      "integrity": "sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==",
-      "dev": true,
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
-      }
     }
   },
   "dependencies": {
@@ -23134,6 +23147,20 @@
           "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
           "dev": true
         }
+      }
+    },
+    "@zod/core": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@zod/core/-/core-0.8.1.tgz",
+      "integrity": "sha512-djj8hPhxIHcG8ptxITaw/Bout5HJZ9NyRbKr95Eilqwt9R0kvITwUQGDU+n+MVdsBIka5KwztmZSLti22F+P0A=="
+    },
+    "@zod/mini": {
+      "version": "4.0.0-beta.20250420T053007",
+      "resolved": "https://registry.npmjs.org/@zod/mini/-/mini-4.0.0-beta.20250420T053007.tgz",
+      "integrity": "sha512-PnQwkzlUbUj6A2GKbqhskH/v58m2WfmP+dbXevzzMdvVA7H/KNao37YWhHOTjBzf+xykCXNoLwfwnPMIsU0hOA==",
+      "dev": true,
+      "requires": {
+        "@zod/core": "0.8.1"
       }
     },
     "abab": {
@@ -31526,12 +31553,6 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
-      "dev": true
-    },
-    "zod": {
-      "version": "3.23.8",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.23.8.tgz",
-      "integrity": "sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==",
       "dev": true
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,6 @@
         "@types/lodash.merge": "^4.6.8",
         "@typescript-eslint/eslint-plugin": "^6.7.5",
         "@typescript-eslint/parser": "^6.7.5",
-        "@zod/mini": "^4.0.0-beta.20250420T053007",
         "antd": "^5.20.5",
         "jest": "^29.7.0",
         "jest-environment-jsdom": "^29.7.0",
@@ -36,11 +35,12 @@
         "storybook": "^7.4.6",
         "ts-jest": "^29.1.1",
         "tsup": "^8.0.2",
-        "typescript": "^5.2.2"
+        "typescript": "^5.2.2",
+        "zod": "^3.25.56"
       },
       "peerDependencies": {
-        "@zod/core": ">=0.8.1",
-        "antd": "^5.20.5"
+        "antd": "^5.20.5",
+        "zod": ">=3.25.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -6961,28 +6961,6 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
       "dev": true
-    },
-    "node_modules/@zod/core": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/@zod/core/-/core-0.8.1.tgz",
-      "integrity": "sha512-djj8hPhxIHcG8ptxITaw/Bout5HJZ9NyRbKr95Eilqwt9R0kvITwUQGDU+n+MVdsBIka5KwztmZSLti22F+P0A==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
-    "node_modules/@zod/mini": {
-      "version": "4.0.0-beta.20250420T053007",
-      "resolved": "https://registry.npmjs.org/@zod/mini/-/mini-4.0.0-beta.20250420T053007.tgz",
-      "integrity": "sha512-PnQwkzlUbUj6A2GKbqhskH/v58m2WfmP+dbXevzzMdvVA7H/KNao37YWhHOTjBzf+xykCXNoLwfwnPMIsU0hOA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@zod/core": "0.8.1"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
-      }
     },
     "node_modules/abab": {
       "version": "2.0.6",
@@ -18349,6 +18327,16 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/zod": {
+      "version": "3.25.56",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.56.tgz",
+      "integrity": "sha512-rd6eEF3BTNvQnR2e2wwolfTmUTnp70aUTqr0oaGbHifzC3BKJsoV+Gat8vxUMR1hwOKBs6El+qWehrHbCpW6SQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
     }
   },
   "dependencies": {
@@ -23147,20 +23135,6 @@
           "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
           "dev": true
         }
-      }
-    },
-    "@zod/core": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/@zod/core/-/core-0.8.1.tgz",
-      "integrity": "sha512-djj8hPhxIHcG8ptxITaw/Bout5HJZ9NyRbKr95Eilqwt9R0kvITwUQGDU+n+MVdsBIka5KwztmZSLti22F+P0A=="
-    },
-    "@zod/mini": {
-      "version": "4.0.0-beta.20250420T053007",
-      "resolved": "https://registry.npmjs.org/@zod/mini/-/mini-4.0.0-beta.20250420T053007.tgz",
-      "integrity": "sha512-PnQwkzlUbUj6A2GKbqhskH/v58m2WfmP+dbXevzzMdvVA7H/KNao37YWhHOTjBzf+xykCXNoLwfwnPMIsU0hOA==",
-      "dev": true,
-      "requires": {
-        "@zod/core": "0.8.1"
       }
     },
     "abab": {
@@ -31553,6 +31527,12 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true
+    },
+    "zod": {
+      "version": "3.25.56",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.56.tgz",
+      "integrity": "sha512-rd6eEF3BTNvQnR2e2wwolfTmUTnp70aUTqr0oaGbHifzC3BKJsoV+Gat8vxUMR1hwOKBs6El+qWehrHbCpW6SQ==",
       "dev": true
     }
   }

--- a/package.json
+++ b/package.json
@@ -63,11 +63,11 @@
     "ts-jest": "^29.1.1",
     "tsup": "^8.0.2",
     "typescript": "^5.2.2",
-    "@zod/mini": "^4.0.0-beta.20250420T053007"
+    "zod": "^3.25.56"
   },
   "peerDependencies": {
     "antd": "^5.20.5",
-    "@zod/core": ">=0.8.1"
+    "zod": ">=3.25.0"
   },
   "dependencies": {
     "lodash.merge": "^4.6.2"

--- a/package.json
+++ b/package.json
@@ -63,11 +63,11 @@
     "ts-jest": "^29.1.1",
     "tsup": "^8.0.2",
     "typescript": "^5.2.2",
-    "zod": "^3.23.8"
+    "@zod/mini": "^4.0.0-beta.20250420T053007"
   },
   "peerDependencies": {
     "antd": "^5.20.5",
-    "zod": ">=3.0.0"
+    "@zod/core": ">=0.8.1"
   },
   "dependencies": {
     "lodash.merge": "^4.6.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "antd-zod",
-  "version": "6.1.0",
+  "version": "7.0.0",
   "description": "Antd Zod validation",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/src/fixtures/index.ts
+++ b/src/fixtures/index.ts
@@ -1,26 +1,37 @@
-import z, { ZodEffects, ZodObject } from "zod";
+import * as z from "@zod/mini";
 
 const UserSchema = z.object({
-  name: z.string().refine((val) => val === "Luka", {
-    message: "Must be Luka",
-  }),
+  name: z
+    .string({
+      error: ({ input }) =>
+        typeof input === "number"
+          ? "Expected string, received number"
+          : "Invalid input",
+    })
+    .check(
+      z.refine((val) => val === "Luka", {
+        message: "Must be Luka",
+      }),
+    ),
 });
 
-export const NameSchema = z
-  .object({
-    name: z.string(),
-  })
-  .required();
+export const NameSchema = z.required(
+  z.object({
+    name: z.string("Required field name"),
+  }),
+);
 
 export const REFINED_NAME_SCHEMA_VALUE = "refined name";
 export const REFINED_NAME_SCHEMA_ERROR = `String must equal ${REFINED_NAME_SCHEMA_VALUE}`;
-export const NameRefinedSchema = z
-  .object({
-    name: z.string().refine((val) => val === REFINED_NAME_SCHEMA_VALUE, {
-      message: REFINED_NAME_SCHEMA_ERROR,
-    }),
-  })
-  .required();
+export const NameRefinedSchema = z.required(
+  z.object({
+    name: z.string().check(
+      z.refine((val) => val === REFINED_NAME_SCHEMA_VALUE, {
+        message: REFINED_NAME_SCHEMA_ERROR,
+      }),
+    ),
+  }),
+);
 
 export const NestedRefinedSchema = z.object({
   user: UserSchema,
@@ -31,13 +42,18 @@ export const ArrayNumberFieldSchema = z.object({
 });
 
 export const ArrayUserFieldSchema = z.object({
-  users: z.array(UserSchema),
+  users: z.array(UserSchema, {
+    error: ({ input }) =>
+      typeof input === "string"
+        ? "Expected array, received string"
+        : "Invalid input",
+  }),
 });
 
-export const RefinedUserFieldSchema = z
-  .object({
-    users: z.array(UserSchema),
-  })
-  .required()
-  // .optional()
-  .refine(() => true);
+export const RefinedUserFieldSchema = z.required(
+  z
+    .object({
+      users: z.array(UserSchema),
+    })
+    .check(z.refine(() => true)),
+);

--- a/src/fixtures/index.ts
+++ b/src/fixtures/index.ts
@@ -1,4 +1,4 @@
-import * as z from "@zod/mini";
+import * as z from "zod/v4-mini";
 
 const UserSchema = z.object({
   name: z

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,7 +1,3 @@
-import z, { ZodRawShape } from "zod";
+import { $ZodObject, $ZodShape } from "@zod/core";
 
-export type AntdFormZodSchema<T extends ZodRawShape> =
-  | z.ZodObject<T>
-  | z.ZodEffects<z.ZodObject<T>>
-  | z.ZodEffects<z.ZodEffects<z.ZodObject<T>>>
-  | z.ZodEffects<z.ZodEffects<z.ZodEffects<z.ZodObject<T>>>>;
+export type AntdFormZodSchema<T extends $ZodShape> = $ZodObject<T>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,3 @@
-import { $ZodObject, $ZodShape } from "@zod/core";
+import { $ZodObject, $ZodShape } from "zod/v4/core";
 
 export type AntdFormZodSchema<T extends $ZodShape> = $ZodObject<T>;

--- a/src/utils/createSchemaFieldRule.spec.ts
+++ b/src/utils/createSchemaFieldRule.spec.ts
@@ -28,7 +28,7 @@ describe("createSchemaFieldValidator", () => {
 
     await expect(
       rule(formInstance).validator?.(fieldRule, {}, () => {}),
-    ).rejects.toEqual(["Required"]);
+    ).rejects.toEqual(["Required field name"]);
   });
   it("should validate successfully NestedRefinedSchema values", async () => {
     const rule = createSchemaFieldRule(NestedRefinedSchema);
@@ -46,7 +46,7 @@ describe("createSchemaFieldValidator", () => {
 
     await expect(
       rule(formInstance).validator?.(fieldRule, {}, () => {}),
-    ).rejects.toEqual(["Required"]);
+    ).rejects.toEqual(["Invalid input"]);
   });
   it("should reject invalid NestedRefinedSchema values", async () => {
     const rule = createSchemaFieldRule(NestedRefinedSchema);

--- a/src/utils/createSchemaFieldRule.ts
+++ b/src/utils/createSchemaFieldRule.ts
@@ -1,4 +1,4 @@
-import { $ZodShape, $ZodType } from "@zod/core";
+import { $ZodShape } from "zod/v4/core";
 import { RuleRender } from "rc-field-form/lib/interface";
 import { AntdFormZodSchema } from "../types";
 import validateFields from "./validateFields";

--- a/src/utils/createSchemaFieldRule.ts
+++ b/src/utils/createSchemaFieldRule.ts
@@ -1,11 +1,11 @@
-import { ZodRawShape } from "zod";
+import { $ZodShape, $ZodType } from "@zod/core";
 import { RuleRender } from "rc-field-form/lib/interface";
 import { AntdFormZodSchema } from "../types";
 import validateFields from "./validateFields";
 import prepareValues from "./prepareValues";
 
 const createSchemaFieldRule =
-  <T extends ZodRawShape>(schema: AntdFormZodSchema<T>): RuleRender =>
+  <T extends $ZodShape>(schema: AntdFormZodSchema<T>): RuleRender =>
   ({ getFieldsValue }) => ({
     validator: (rule) =>
       new Promise(async (resolve, reject) => {

--- a/src/utils/formatErrors.spec.ts
+++ b/src/utils/formatErrors.spec.ts
@@ -1,6 +1,6 @@
 import formatErrors from "./formatErrors";
 import prepareValues from "./prepareValues";
-import { z } from "@zod/mini";
+import { z } from "zod/v4";
 
 describe("formatErrors", () => {
   it("should return empty errors", async () => {
@@ -27,7 +27,9 @@ describe("formatErrors", () => {
     }
     const formattedErrors = formatErrors<{}>(schema, res.error);
 
-    expect(formattedErrors).toEqual({ prop: ["Invalid input"] });
+    expect(formattedErrors).toEqual({
+      prop: ["Invalid input: expected string, received undefined"],
+    });
   });
   it("should format nested prop.child error", async () => {
     const schema = z.object({
@@ -42,7 +44,9 @@ describe("formatErrors", () => {
     }
     const formattedErrors = formatErrors<{}>(schema, res.error);
 
-    expect(formattedErrors).toEqual({ "prop.child": ["Invalid input"] });
+    expect(formattedErrors).toEqual({
+      "prop.child": ["Invalid input: expected string, received undefined"],
+    });
   });
   it("should return multiple errors", async () => {
     const multipleErrorSchema = z.object({

--- a/src/utils/formatErrors.spec.ts
+++ b/src/utils/formatErrors.spec.ts
@@ -1,13 +1,11 @@
-import z, { ZodError, ZodIssue } from "zod";
 import formatErrors from "./formatErrors";
 import prepareValues from "./prepareValues";
-
-const schema = z.object({ field: z.string() });
+import { z } from "@zod/mini";
 
 describe("formatErrors", () => {
   it("should return empty errors", async () => {
     const schema = z.object({
-      prop: z.string().optional(),
+      prop: z.optional(z.string()),
     });
 
     const res = await schema.safeParseAsync({});
@@ -29,7 +27,7 @@ describe("formatErrors", () => {
     }
     const formattedErrors = formatErrors<{}>(schema, res.error);
 
-    expect(formattedErrors).toEqual({ prop: ["Required"] });
+    expect(formattedErrors).toEqual({ prop: ["Invalid input"] });
   });
   it("should format nested prop.child error", async () => {
     const schema = z.object({
@@ -44,11 +42,18 @@ describe("formatErrors", () => {
     }
     const formattedErrors = formatErrors<{}>(schema, res.error);
 
-    expect(formattedErrors).toEqual({ "prop.child": ["Required"] });
+    expect(formattedErrors).toEqual({ "prop.child": ["Invalid input"] });
   });
   it("should return multiple errors", async () => {
     const multipleErrorSchema = z.object({
-      email: z.string().email().min(5).max(15).includes(".com"),
+      email: z
+        .string()
+        .check(
+          z.email("Invalid email"),
+          z.minLength(5, "String must contain at least 5 character(s)"),
+          z.maxLength(15),
+          z.includes(".com", 'Invalid input: must include ".com"'),
+        ),
     });
 
     const res = await multipleErrorSchema.safeParseAsync(
@@ -57,7 +62,7 @@ describe("formatErrors", () => {
     if (res.success) {
       return;
     }
-    const formattedErrors = formatErrors<{}>(schema, res.error);
+    const formattedErrors = formatErrors<{}>(multipleErrorSchema, res.error);
     expect(formattedErrors).toEqual({
       email: [
         "Invalid email",

--- a/src/utils/formatErrors.ts
+++ b/src/utils/formatErrors.ts
@@ -1,12 +1,12 @@
-import { ZodError } from "zod/lib/ZodError";
+import { $ZodError } from "@zod/core";
 import getSchemaBaseSchema from "./getSchemaBaseSchema";
-import { ZodRawShape, ZodTypeAny } from "zod";
+import { $ZodShape, $ZodType } from "@zod/core";
 import { isZodObject } from "./schema";
 import getIssueAntdPath from "./getIssueAntdPath";
 
-const formatErrors = <T extends ZodRawShape>(
-  schema: ZodTypeAny,
-  errors: ZodError<T>,
+const formatErrors = <T extends $ZodShape>(
+  schema: $ZodType,
+  errors: $ZodError<T>,
 ): { [key: string]: string[] } => {
   if (errors.issues.length === 0) {
     return {};

--- a/src/utils/formatErrors.ts
+++ b/src/utils/formatErrors.ts
@@ -1,6 +1,5 @@
-import { $ZodError } from "@zod/core";
+import { $ZodError, $ZodShape, $ZodType } from "zod/v4/core";
 import getSchemaBaseSchema from "./getSchemaBaseSchema";
-import { $ZodShape, $ZodType } from "@zod/core";
 import { isZodObject } from "./schema";
 import getIssueAntdPath from "./getIssueAntdPath";
 

--- a/src/utils/getIssueAntdPath.ts
+++ b/src/utils/getIssueAntdPath.ts
@@ -1,4 +1,4 @@
-import { $ZodIssue, $ZodType } from "@zod/core";
+import { $ZodIssue, $ZodType } from "zod/v4/core";
 import { isZodObject, isZodArray } from "./schema";
 import getSchemaBaseSchema from "./getSchemaBaseSchema";
 

--- a/src/utils/getIssueAntdPath.ts
+++ b/src/utils/getIssueAntdPath.ts
@@ -1,11 +1,11 @@
-import { ZodIssue, ZodTypeAny } from "zod";
+import { $ZodIssue, $ZodType } from "@zod/core";
 import { isZodObject, isZodArray } from "./schema";
 import getSchemaBaseSchema from "./getSchemaBaseSchema";
 
 const concatAntdPath = (antdPath: string[]) => antdPath.join(".");
 const prepareZodPath = (antdPath: string) => antdPath.replace(/\.\d+/, "");
 const serializePath = (
-  schema: ZodTypeAny,
+  schema: $ZodType,
   zodPath: string[],
   antdPath: string[] = [],
 ): string => {
@@ -21,13 +21,17 @@ const serializePath = (
 
     const replacedPath = prepareZodPath(subPath);
     const subPathBaseSchema = getSchemaBaseSchema(
-      baseSchema.shape[replacedPath],
+      baseSchema._zod.def.shape[replacedPath],
     );
 
     if (isZodObject(subPathBaseSchema))
       return serializePath(subPathBaseSchema, zodPath, antdPath);
     if (isZodArray(subPathBaseSchema))
-      return serializePath(subPathBaseSchema.element, zodPath, antdPath);
+      return serializePath(
+        subPathBaseSchema._zod.def.element,
+        zodPath,
+        antdPath,
+      );
 
     return concatAntdPath(antdPath);
   }
@@ -35,17 +39,19 @@ const serializePath = (
   throw new Error("Unknown zod schema");
 };
 
-const prepareAntdPath = (path: (string | number)[]) => {
+const prepareAntdPath = (path: (string | number | symbol)[]) => {
   return path.reduce<string[]>((prev: string[], curr) => {
     if (typeof curr === "number") {
       const base = [...prev].slice(0, -1);
       return [...base, `${prev.slice(-1)[0]}.${curr}`];
+    } else if (typeof curr === "symbol") {
+      return [...prev, curr.toString()];
     }
     return [...prev, curr];
   }, []);
 };
 
-const getIssueAntdPath = (schema: ZodTypeAny, issue: ZodIssue) => {
+const getIssueAntdPath = (schema: $ZodType, issue: $ZodIssue) => {
   const preparedPath = prepareAntdPath(issue.path);
 
   const zodPath = preparedPath.reverse() as string[];

--- a/src/utils/getNestedPlaceholders.spec.ts
+++ b/src/utils/getNestedPlaceholders.spec.ts
@@ -1,16 +1,15 @@
 import { NameSchema, NestedRefinedSchema } from "../fixtures";
 import getNestedPlaceholders from "./getNestedPlaceholders";
-import z from "zod";
-import prepareValues from "./prepareValues";
+import * as z from "@zod/mini";
 
 const NestedOptionalSchema = z.object({
-  nestedObject: z
-    .object({
+  nestedObject: z.optional(
+    z.object({
       childObject: z.object({
         prop: z.string(),
       }),
-    })
-    .optional(),
+    }),
+  ),
 });
 
 describe("getNestedPlaceholders", () => {

--- a/src/utils/getNestedPlaceholders.spec.ts
+++ b/src/utils/getNestedPlaceholders.spec.ts
@@ -1,6 +1,6 @@
 import { NameSchema, NestedRefinedSchema } from "../fixtures";
 import getNestedPlaceholders from "./getNestedPlaceholders";
-import * as z from "@zod/mini";
+import * as z from "zod/v4-mini";
 
 const NestedOptionalSchema = z.object({
   nestedObject: z.optional(

--- a/src/utils/getNestedPlaceholders.ts
+++ b/src/utils/getNestedPlaceholders.ts
@@ -1,4 +1,4 @@
-import { $ZodShape } from "@zod/core";
+import { $ZodShape } from "zod/v4/core";
 import { AntdFormZodSchema } from "../types";
 import { getZodSchemaShape, isZodObject, isZodOptional } from "./schema";
 import getSchemaBaseSchema from "./getSchemaBaseSchema";

--- a/src/utils/getNestedPlaceholders.ts
+++ b/src/utils/getNestedPlaceholders.ts
@@ -1,9 +1,9 @@
-import { ZodObject, ZodRawShape } from "zod";
+import { $ZodShape } from "@zod/core";
 import { AntdFormZodSchema } from "../types";
-import { getZodSchemaShape, isZodOptional } from "./schema";
+import { getZodSchemaShape, isZodObject, isZodOptional } from "./schema";
 import getSchemaBaseSchema from "./getSchemaBaseSchema";
 
-const getNestedPlaceholders = <T extends ZodRawShape>(
+const getNestedPlaceholders = <T extends $ZodShape>(
   schema: AntdFormZodSchema<T>,
   values: Record<string, any> = {},
 ): {} => {
@@ -15,7 +15,7 @@ const getNestedPlaceholders = <T extends ZodRawShape>(
     }
 
     const fieldSchema = getSchemaBaseSchema(field);
-    if (fieldSchema instanceof ZodObject) {
+    if (isZodObject(fieldSchema)) {
       return {
         ...res,
         [key]: getNestedPlaceholders(fieldSchema, values[key]),

--- a/src/utils/getSchemaBaseSchema.spec.ts
+++ b/src/utils/getSchemaBaseSchema.spec.ts
@@ -1,4 +1,4 @@
-import * as z from "@zod/mini";
+import * as z from "zod/v4-mini";
 import getSchemaBaseSchema from "./getSchemaBaseSchema";
 
 describe("getSchemaBaseSchema", () => {

--- a/src/utils/getSchemaBaseSchema.spec.ts
+++ b/src/utils/getSchemaBaseSchema.spec.ts
@@ -1,4 +1,4 @@
-import z from "zod";
+import * as z from "@zod/mini";
 import getSchemaBaseSchema from "./getSchemaBaseSchema";
 
 describe("getSchemaBaseSchema", () => {
@@ -20,22 +20,6 @@ describe("getSchemaBaseSchema", () => {
 
     expect(baseSchema).toBe(arraySchema);
   });
-  it("should get refined base schema", () => {
-    const arrayBaseSchema = z.array(z.string());
-    const arrayRefinedSchema = arrayBaseSchema.refine(() => true);
-    const baseSchema = getSchemaBaseSchema(arrayRefinedSchema);
-
-    expect(baseSchema).toBe(arrayBaseSchema);
-  });
-  it("should get nested refined base schema", () => {
-    const arrayBaseSchema = z.array(z.string());
-    const arrayRefinedSchema = arrayBaseSchema
-      .refine(() => true)
-      .refine(() => true);
-    const baseSchema = getSchemaBaseSchema(arrayRefinedSchema);
-
-    expect(baseSchema).toBe(arrayBaseSchema);
-  });
   it("should get object base schema", () => {
     const objectBaseSchema = z.object({});
     const baseSchema = getSchemaBaseSchema(objectBaseSchema);
@@ -44,32 +28,26 @@ describe("getSchemaBaseSchema", () => {
   });
   it("should get optional object base schema", () => {
     const objectBaseSchema = z.object({});
-    const objectSchema = objectBaseSchema.optional();
+    const objectSchema = z.optional(objectBaseSchema);
     const baseSchema =
       getSchemaBaseSchema<typeof objectBaseSchema>(objectSchema);
 
     expect(baseSchema).toBe(objectBaseSchema);
   });
   it("should get required object schema", () => {
-    const objectBaseSchema = z.object({});
-    const objectSchema = objectBaseSchema.required();
+    const objectBaseSchema = z.object({
+      nestedObject: z.string(),
+    });
+    const objectSchema = z.required(objectBaseSchema);
     const baseSchema =
       getSchemaBaseSchema<typeof objectBaseSchema>(objectSchema);
 
     // Required doesn't create new schema
     expect(baseSchema).toBe(objectSchema);
   });
-  it("should get refined object base schema", () => {
-    const objectBaseSchema = z.object({});
-    const objectSchema = objectBaseSchema.refine(() => true);
-    const baseSchema =
-      getSchemaBaseSchema<typeof objectBaseSchema>(objectSchema);
-
-    expect(baseSchema).toBe(objectBaseSchema);
-  });
   it("should get nullish object base schema", () => {
     const objectBaseSchema = z.object({});
-    const objectSchema = objectBaseSchema.nullish();
+    const objectSchema = z.nullish(objectBaseSchema);
     const baseSchema =
       getSchemaBaseSchema<typeof objectBaseSchema>(objectSchema);
 
@@ -77,14 +55,14 @@ describe("getSchemaBaseSchema", () => {
   });
   it("should get nullable object base schema", () => {
     const objectBaseSchema = z.object({});
-    const objectSchema = objectBaseSchema.nullable();
+    const objectSchema = z.nullable(objectBaseSchema);
     const baseSchema =
       getSchemaBaseSchema<typeof objectBaseSchema>(objectSchema);
 
     expect(baseSchema).toBe(objectBaseSchema);
   });
   it("should get merged object base schema", () => {
-    const objectBaseSchema = z.object({}).merge(z.object({}));
+    const objectBaseSchema = z.merge(z.object({}), z.object({}));
     const baseSchema =
       getSchemaBaseSchema<typeof objectBaseSchema>(objectBaseSchema);
 

--- a/src/utils/getSchemaBaseSchema.ts
+++ b/src/utils/getSchemaBaseSchema.ts
@@ -1,11 +1,11 @@
-import { ZodTypeAny } from "zod";
-import { isZodOptional, isZodEffect } from "./schema";
+import { isZodNullable, isZodOptional } from "./schema";
+import { $ZodType } from "@zod/core";
 
-const getSchemaBaseSchema = <T extends ZodTypeAny>(schema: ZodTypeAny): T => {
-  if (isZodEffect(schema)) {
-    return getSchemaBaseSchema(schema._def.schema);
-  } else if (isZodOptional(schema)) {
-    return getSchemaBaseSchema(schema._def.innerType);
+const getSchemaBaseSchema = <T extends $ZodType>(schema: $ZodType): T => {
+  if (isZodOptional(schema)) {
+    return getSchemaBaseSchema(schema._zod.def.innerType);
+  } else if (isZodNullable(schema)) {
+    return getSchemaBaseSchema(schema._zod.def.innerType);
   }
 
   return schema as T;

--- a/src/utils/getSchemaBaseSchema.ts
+++ b/src/utils/getSchemaBaseSchema.ts
@@ -1,5 +1,5 @@
 import { isZodNullable, isZodOptional } from "./schema";
-import { $ZodType } from "@zod/core";
+import { $ZodType } from "zod/v4/core";
 
 const getSchemaBaseSchema = <T extends $ZodType>(schema: $ZodType): T => {
   if (isZodOptional(schema)) {

--- a/src/utils/prepareValues.spec.ts
+++ b/src/utils/prepareValues.spec.ts
@@ -1,5 +1,5 @@
 import prepareValues from "./prepareValues";
-import * as z from "@zod/mini";
+import * as z from "zod/v4-mini";
 
 const NestedSchema = z.object({
   nestedObject: z.object({

--- a/src/utils/prepareValues.spec.ts
+++ b/src/utils/prepareValues.spec.ts
@@ -1,7 +1,6 @@
 import prepareValues from "./prepareValues";
-import z from "zod";
+import * as z from "@zod/mini";
 
-const PrimitiveSchema = z.object({});
 const NestedSchema = z.object({
   nestedObject: z.object({
     childObject: z.object({
@@ -10,25 +9,18 @@ const NestedSchema = z.object({
   }),
 });
 const OptionalSchema = z.object({
-  optionalObject: z.object({}).optional(),
+  optionalObject: z.optional(z.object({})),
 });
 const NestedRefinementSchema = z
   .object({
-    optionalObject: z.object({}).optional(),
+    optionalObject: z.optional(z.object({})),
   })
-  .refine(() => true)
-  .refine(() => true);
+  .check(
+    z.refine(() => true),
+    z.refine(() => true),
+  );
 
 describe("prepareValues", () => {
-  it("should return empty values", async () => {
-    const placeholders = prepareValues(PrimitiveSchema, {});
-    expect(placeholders).toEqual({});
-  });
-  it("should return values", async () => {
-    const values = { test: 1 };
-    const placeholders = prepareValues(PrimitiveSchema, values);
-    expect(placeholders).toEqual(values);
-  });
   it("should return empty values with placeholders", async () => {
     const placeholders = prepareValues(NestedSchema, {});
     expect(placeholders).toEqual({

--- a/src/utils/prepareValues.ts
+++ b/src/utils/prepareValues.ts
@@ -1,11 +1,11 @@
 import merge from "lodash.merge";
 import getNestedPlaceholders from "./getNestedPlaceholders";
-import { ZodRawShape } from "zod";
+import { $ZodShape } from "@zod/core";
 import { AntdFormZodSchema } from "../types";
 
 // Antd expects single field validation and Zod invalidates missing object fields (as whole).
 // Placeholders help get individual field validation on required object fields.
-const prepareValues = <T extends ZodRawShape>(
+const prepareValues = <T extends $ZodShape>(
   schema: AntdFormZodSchema<T>,
   values: {},
 ) => merge({}, getNestedPlaceholders(schema, values), values);

--- a/src/utils/prepareValues.ts
+++ b/src/utils/prepareValues.ts
@@ -1,6 +1,6 @@
 import merge from "lodash.merge";
 import getNestedPlaceholders from "./getNestedPlaceholders";
-import { $ZodShape } from "@zod/core";
+import { $ZodShape } from "zod/v4/core";
 import { AntdFormZodSchema } from "../types";
 
 // Antd expects single field validation and Zod invalidates missing object fields (as whole).

--- a/src/utils/schema.ts
+++ b/src/utils/schema.ts
@@ -4,9 +4,9 @@ import {
   $ZodOptional,
   $ZodObject,
   $ZodNullable,
-} from "@zod/core";
+  $ZodType,
+} from "zod/v4/core";
 import { AntdFormZodSchema } from "../types";
-import { $ZodType } from "@zod/core";
 
 export const isZodOptional = (schema: $ZodType): schema is $ZodOptional =>
   schema._zod.def.type === "optional";

--- a/src/utils/schema.ts
+++ b/src/utils/schema.ts
@@ -1,25 +1,25 @@
-import z, { ZodRawShape } from "zod";
+import {
+  $ZodShape,
+  $ZodArray,
+  $ZodOptional,
+  $ZodObject,
+  $ZodNullable,
+} from "@zod/core";
 import { AntdFormZodSchema } from "../types";
+import { $ZodType } from "@zod/core";
 
-export const isZodEffect = (schema: unknown): schema is z.ZodEffects<any> =>
-  typeof schema === "object" &&
-  !!schema &&
-  !("shape" in schema) &&
-  "_def" in schema &&
-  typeof schema._def === "object" &&
-  !!schema._def &&
-  "schema" in schema._def;
+export const isZodOptional = (schema: $ZodType): schema is $ZodOptional =>
+  schema._zod.def.type === "optional";
 
-export const isZodOptional = (schema: unknown): schema is z.ZodOptional<any> =>
-  typeof schema === "object" && !!schema && "unwrap" in schema;
+export const isZodNullable = (schema: $ZodType): schema is $ZodNullable =>
+  schema._zod.def.type === "nullable";
 
-export const isZodObject = (schema: unknown): schema is z.ZodObject<any> =>
-  typeof schema === "object" && !!schema && "shape" in schema;
+export const isZodObject = (schema: $ZodType): schema is $ZodObject =>
+  schema._zod.def.type === "object";
 
-export const isZodArray = (schema: unknown): schema is z.ZodArray<any> =>
-  schema instanceof z.ZodArray;
+export const isZodArray = (schema: $ZodType): schema is $ZodArray =>
+  schema._zod.def.type === "array";
 
-export const getZodSchemaShape = <T extends ZodRawShape>(
+export const getZodSchemaShape = <T extends $ZodShape>(
   schema: AntdFormZodSchema<T>,
-): ZodRawShape =>
-  isZodEffect(schema) ? getZodSchemaShape(schema._def.schema) : schema.shape;
+): T => schema._zod.def.shape;

--- a/src/utils/validateFields.spec.ts
+++ b/src/utils/validateFields.spec.ts
@@ -12,17 +12,17 @@ describe("validateFields", () => {
   });
   it("should return errors", async () => {
     expect(await validateFields(NameSchema, {})).toEqual({
-      name: ["Required"],
+      name: ["Required field name"],
     });
   });
   it("should return errors for nested schemas", async () => {
     expect(await validateFields(NestedRefinedSchema, {})).toEqual({
-      "user.name": ["Required"],
+      "user.name": ["Invalid input"],
     });
   });
   it("should return errors for primitive array field", async () => {
     expect(await validateFields(ArrayNumberFieldSchema, {})).toEqual({
-      numbers: ["Required"],
+      numbers: ["Invalid input"],
     });
   });
   it("should return errors for object array field", async () => {
@@ -35,7 +35,7 @@ describe("validateFields", () => {
 
   it("should return errors for object array field items", async () => {
     expect(await validateFields(ArrayUserFieldSchema, { users: [1] })).toEqual({
-      "users.0": ["Expected object, received number"],
+      "users.0": ["Invalid input"],
     });
 
     expect(

--- a/src/utils/validateFields.ts
+++ b/src/utils/validateFields.ts
@@ -1,5 +1,5 @@
 import { AntdFormZodSchema } from "../types";
-import { $ZodShape } from "zod/v4/core";
+import { $ZodError, $ZodShape, safeParseAsync } from "zod/v4/core";
 import prepareValues from "./prepareValues";
 import formatErrors from "./formatErrors";
 
@@ -9,14 +9,13 @@ const validateFields = async <T extends $ZodShape>(
 ): Promise<{ [key: string]: string[] }> => {
   const valuesWithPlaceholders = prepareValues(schema, values);
 
-  // @ts-ignore
-  const res = await schema.safeParseAsync(valuesWithPlaceholders);
+  const res = await safeParseAsync(schema, valuesWithPlaceholders);
 
   if (res.success) {
     return {} as Record<keyof T, string[]>;
   }
 
-  return formatErrors(schema, res.error);
+  return formatErrors(schema, res.error as $ZodError<T>);
 };
 
 export default validateFields;

--- a/src/utils/validateFields.ts
+++ b/src/utils/validateFields.ts
@@ -1,14 +1,15 @@
 import { AntdFormZodSchema } from "../types";
-import { ZodRawShape } from "zod";
+import { $ZodShape } from "@zod/core";
 import prepareValues from "./prepareValues";
 import formatErrors from "./formatErrors";
 
-const validateFields = async <T extends ZodRawShape>(
+const validateFields = async <T extends $ZodShape>(
   schema: AntdFormZodSchema<T>,
   values: {},
 ): Promise<{ [key: string]: string[] }> => {
   const valuesWithPlaceholders = prepareValues(schema, values);
 
+  // @ts-ignore
   const res = await schema.safeParseAsync(valuesWithPlaceholders);
 
   if (res.success) {

--- a/src/utils/validateFields.ts
+++ b/src/utils/validateFields.ts
@@ -1,5 +1,5 @@
 import { AntdFormZodSchema } from "../types";
-import { $ZodShape } from "@zod/core";
+import { $ZodShape } from "zod/v4/core";
 import prepareValues from "./prepareValues";
 import formatErrors from "./formatErrors";
 

--- a/stories/basic.stories.tsx
+++ b/stories/basic.stories.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { Form, Input, Button, InputNumber, Select, Col, Card } from "antd";
-import * as z from "@zod/mini";
+import * as z from "zod/v4-mini";
 import { createSchemaFieldRule } from "../src";
 import { CloseOutlined } from "@ant-design/icons";
 

--- a/stories/basic.stories.tsx
+++ b/stories/basic.stories.tsx
@@ -1,45 +1,61 @@
 import React from "react";
 import { Form, Input, Button, InputNumber, Select, Col, Card } from "antd";
-import z from "zod";
+import * as z from "@zod/mini";
 import { createSchemaFieldRule } from "../src";
 import { CloseOutlined } from "@ant-design/icons";
 
-const VALUES = ["Male", "Female"] as const;
-const Genders = z.enum(VALUES);
+const Genders = z.enum(["Male", "Female"]);
 
 const Cities = z.enum(["New York", "Peking", "Paris", "London"]);
 
 const Child = z.object({
   name: z
     .string({
-      invalid_type_error: "must be string",
-      required_error: "required",
+      error: ({ input }) => {
+        if (typeof input !== "string") {
+          return "must be string";
+        }
+        if (input === undefined) {
+          return "required";
+        }
+      },
     })
-    .min(1),
+    .check(z.minLength(1)),
   toys: z
-    .object({
-      name: z
-        .string({
-          invalid_type_error: "must be string",
-          required_error: "required",
-        })
-        .min(2),
-    })
-    .array()
-    .min(2),
+    .array(
+      z.object({
+        name: z
+          .string({
+            error: ({ input }) => {
+              if (typeof input !== "string") {
+                return "must be string";
+              }
+              if (input === undefined) {
+                return "required";
+              }
+            },
+          })
+          .check(z.minLength(2, "Min 2 characters")),
+      }),
+    )
+    .check(z.minLength(2)),
 });
 
 const BasicSchema = z.object({
-  email: z.string().email().min(5).max(15).includes('.com'),
-  name: z.string().refine((value) => value.length > 2, {
-    message: "Must have more than 2 chars",
-  }),
+  email: z
+    .string()
+    .check(z.email(), z.minLength(5), z.maxLength(15), z.includes(".com")),
+  name: z.string().check(
+    z.refine((value) => value.length > 2, {
+      message: "Must have more than 2 chars",
+    }),
+  ),
   height: z.number(),
-  gender: Genders.optional(),
+  gender: z.optional(Genders),
   address: z.object({
     city: Cities,
   }),
-  children: Child.array().min(2),
+  children: z.array(Child).check(z.minLength(2)),
 });
 
 const rule = createSchemaFieldRule(BasicSchema);

--- a/stories/refined.stories.tsx
+++ b/stories/refined.stories.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { Form, Input, Button } from "antd";
-import z from "zod";
+import * as z from "@zod/mini";
 import { createSchemaFieldRule } from "../src";
 
 const PasswordSchema = z
@@ -8,16 +8,18 @@ const PasswordSchema = z
     password: z.string(),
     passwordCopy: z.string(),
   })
-  .refine(({ password, passwordCopy }) => password === passwordCopy, {
-    message: "Passwords must match",
-    // NOTE THE PATH!
-    path: ["passwordCopy"],
-  })
-  .refine(({ password }) => password.length > 3, {
-    message: "Password must have at least 3 characters",
-    // NOTE THE PATH!
-    path: ["password"],
-  });
+  .check(
+    z.refine(({ password, passwordCopy }) => password === passwordCopy, {
+      error: "Passwords must match",
+      // NOTE THE PATH!
+      path: ["passwordCopy"],
+    }),
+    z.refine(({ password }) => password.length >= 3, {
+      error: "Password must have at least 3 characters",
+      // NOTE THE PATH!
+      path: ["password"],
+    }),
+  );
 
 const rule = createSchemaFieldRule(PasswordSchema);
 

--- a/stories/refined.stories.tsx
+++ b/stories/refined.stories.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { Form, Input, Button } from "antd";
-import * as z from "@zod/mini";
+import * as z from "zod/v4-mini";
 import { createSchemaFieldRule } from "../src";
 
 const PasswordSchema = z

--- a/stories/super-refined.stories.tsx
+++ b/stories/super-refined.stories.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { Form, Input, Button } from "antd";
-import z from "zod";
+import * as z from "@zod/mini";
 import { createSchemaFieldRule } from "../src";
 
 const PasswordSchema = z
@@ -8,11 +8,11 @@ const PasswordSchema = z
     password: z.string(),
     passwordCopy: z.string(),
   })
-  .superRefine((val, ctx) => {
-    if (val.password.length < 2) {
-      ctx.addIssue({
+  .check((ctx) => {
+    if (ctx.value.password.length < 2) {
+      ctx.issues.push({
+        input: ctx.value,
         path: ["password"],
-        code: z.ZodIssueCode.too_big,
         maximum: 3,
         type: "array",
         inclusive: true,

--- a/stories/super-refined.stories.tsx
+++ b/stories/super-refined.stories.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { Form, Input, Button } from "antd";
-import * as z from "@zod/mini";
+import * as z from "zod/v4-mini";
 import { createSchemaFieldRule } from "../src";
 
 const PasswordSchema = z
@@ -17,6 +17,7 @@ const PasswordSchema = z
         type: "array",
         inclusive: true,
         message: "Too many items 😡",
+        code: "custom",
       });
     }
   });


### PR DESCRIPTION
Add Zod 4 support (#20).

The general idea was to use `@zod/core` building blocks without making the library aware of Zod or Zod mini.

Open issues:
- [ ] How to parse the input values without `zod/mini` dependency - https://github.com/MrBr/antd-zod/compare/zod-4?expand=1#diff-16dfb04f8b2d97d476fb47030650299faaf3c725dc4aa427b256c9a1209fc88cR13
- [ ] Empty objects sometime cause TS issues. Not sure if this is intended (i.e. `z.required(z.object({}))`